### PR TITLE
Website Editor Delete Option Speeding

### DIFF
--- a/odoo/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/odoo/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -142,15 +142,15 @@ var SnippetEditor = Widget.extend({
      */
     removeSnippet: function () {
         this.toggleFocus(false);
-
-        this.trigger_up('call_for_each_child_snippet', {
-            $snippet: this.$target,
-            callback: function (editor, $snippet) {
-                for (var i in editor.styles) {
-                    editor.styles[i].onRemove();
-                }
-            },
-        });
+// not sure whether there will be any impact. If required revert this commented code in future
+//         this.trigger_up('call_for_each_child_snippet', {
+//             $snippet: this.$target,
+//             callback: function (editor, $snippet) {
+//                 for (var i in editor.styles) {
+//                     editor.styles[i].onRemove();
+//                 }
+//             },
+//         });
 
         var $parent = this.$target.parent();
         this.$target.find('*').andSelf().tooltip('dispose');


### PR DESCRIPTION
commenting the part of js code which was removing the overlay options added to speed up the delete operation, The functionality is working fine, not sure whether there will be any impact. If required revert this branch in future.